### PR TITLE
Tradução de um gráfico e duas tabelas

### DIFF
--- a/inst/app/modules/empresas/tableEmp.R
+++ b/inst/app/modules/empresas/tableEmp.R
@@ -27,7 +27,9 @@ tableEmp <- function(input, output, session, df_pesq) {
       ) %>% 
       DT::datatable(
         rownames = FALSE, 
-        options = list(pageLength = 5)
+        options = list(
+          pageLength = 5,
+          language = list(url = '//cdn.datatables.net/plug-ins/1.10.11/i18n/Portuguese-Brasil.json'))
       )
   })
   

--- a/inst/app/modules/estatisticos/tableStat.R
+++ b/inst/app/modules/estatisticos/tableStat.R
@@ -27,7 +27,9 @@ tableStat <- function(input, output, session, df_pesq) {
       ) %>% 
       DT::datatable(
         rownames = FALSE, 
-        options = list(pageLength = 5)
+        options = list(
+          pageLength = 5,
+          language = list(url = '//cdn.datatables.net/plug-ins/1.10.11/i18n/Portuguese-Brasil.json'))
       )
   })
   

--- a/inst/app/modules/geral/geral-barplot.R
+++ b/inst/app/modules/geral/geral-barplot.R
@@ -17,7 +17,7 @@ barplot <- function(input, output, session, df_pesq) {
     
     df_pesq %>%
       dplyr::mutate(
-        month = lubridate::month(dt_reg, label = TRUE),
+        month = lubridate::month(dt_reg, label = TRUE, locale = "pt_BR"),
         abrangencia = ifelse(info_uf == "BR", "nac", "est")
       ) %>%
       dplyr::count(abrangencia, month) %>% 


### PR DESCRIPTION
O gráfico de _Pesquisas por mês_, a tabela geral de empresas e a tabela geral de estatísticos estavam com alguns detalhes em inglês por usarem os ajustes default dos pacotes `lubridate` e `DT`.

O primeiro commit do pull request resolve o problema dos meses em inglês no gráfico e o segundo commit resolve o problema dos textos em inglês nas tabelas.